### PR TITLE
Merge of Custom Elites/Buffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+ItemLib/ItemLib.xml

--- a/ExampleItemMod/ExampleItemMod.cs
+++ b/ExampleItemMod/ExampleItemMod.cs
@@ -62,16 +62,16 @@ namespace ExampleItemMod
             //(Though, by the way, it has a built-in sticky bomb)
             var card = new EliteAffixCard
             {
-                spawnWeight = 0.1f,
-                costMultiplier = 6.0f,
-                damageBoostCoeff = 2.0f,
-                healthBoostCoeff = 4.7f,
+                spawnWeight = 0.1f,         //Only 10% as likely to spawn compared to baseline vanilla elites
+                costMultiplier = 6.0f,      //Costs 6x, which is the same as tier 1 elites
+                damageBoostCoeff = 2.0f,    //Damage boost the same as vanilla elites
+                healthBoostCoeff = 4.7f,    //Health boost the same as vanilla elites
                 eliteType = (EliteIndex) eliteId,
                 onSpawned = m => m.inventory.GiveItem(ItemIndex.StickyBomb, 1)
             };
 
             //Except it's really common on beetles for some reason
-            card.spawnCardMultipliers.Add("cscbeetle", 20);
+            card.spawnCardMultipliers.Add("cscbeetle", 20); //20x more likely than vanilla for this elite type to be chosen on Beetles
 
             //Add it to the list so that it's available for spawning with ESO
             EliteSpawningOverhaul.Cards.Add(card);
@@ -120,6 +120,21 @@ namespace ExampleItemMod
             };
 
             return new CustomItem(newItemDef, _prefab, _icon, _itemDisplayRules);
+        }
+
+        [Item(ItemAttribute.ItemType.Buff)]
+        public static CustomBuff TestBuff()
+        {
+            LoadAssets();
+
+            var buffDef = new BuffDef
+            {
+                buffColor = Color.green,
+                canStack = false
+            };
+
+            Sprite icon = null; //Can load a custom sprite asset here; null defaults to a blank colored square
+            return new CustomBuff("MyBuff", buffDef, icon);
         }
 
         [Item(ItemAttribute.ItemType.Elite)]

--- a/ExampleItemMod/ExampleItemMod.cs
+++ b/ExampleItemMod/ExampleItemMod.cs
@@ -57,6 +57,24 @@ namespace ExampleItemMod
                     orig(self, BuffIndex.Cloak, count);
                 }
             };
+
+            //Overall, this elite is pretty rare
+            //(Though, by the way, it has a built-in sticky bomb)
+            var card = new EliteAffixCard
+            {
+                spawnWeight = 0.1f,
+                costMultiplier = 6.0f,
+                damageBoostCoeff = 2.0f,
+                healthBoostCoeff = 4.7f,
+                eliteType = (EliteIndex) eliteId,
+                onSpawned = m => m.inventory.GiveItem(ItemIndex.StickyBomb, 1)
+            };
+
+            //Except it's really common on beetles for some reason
+            card.spawnCardMultipliers.Add("cscbeetle", 20);
+
+            //Add it to the list so that it's available for spawning with ESO
+            EliteSpawningOverhaul.Cards.Add(card);
         }
 
         private static void DetonateAlive(float radius)

--- a/ItemLib.MonoMod/Attributes.cs
+++ b/ItemLib.MonoMod/Attributes.cs
@@ -8,6 +8,12 @@ namespace RoR2
     public class NoInlining : Attribute
     {
     }
+
+    [MonoModCustomMethodAttribute("NoReadOnly")]
+    public class NoReadOnly : Attribute
+    {
+
+    }
 }
 
 namespace MonoMod
@@ -16,5 +22,7 @@ namespace MonoMod
     {
         // ReSharper disable once UnusedParameter.Global
         public static void NoInlining(MethodDefinition method, CustomAttribute attrib) => method.NoInlining = true;
+
+        public static void NoReadOnly(FieldDefinition field, CustomAttribute attrib) => field.IsInitOnly = false;
     }
 }

--- a/ItemLib.MonoMod/ItemLib_MonoMod.cs
+++ b/ItemLib.MonoMod/ItemLib_MonoMod.cs
@@ -24,6 +24,20 @@ namespace RoR2
         public static extern EquipmentDef GetEquipmentDef(EquipmentIndex equipmentIndex);
     }
 
+    internal class patch_EliteCatalog
+    {
+        [MonoModIgnore]
+        [NoInlining]
+        public static extern EliteDef GetEliteDef(EliteIndex eliteIndex);
+    }
+
+    internal class patch_BuffCatalog
+    {
+        [MonoModIgnore]
+        [NoInlining]
+        public static extern BuffDef GetBuffDef(BuffIndex buffIndex);
+    }
+
     [Serializable]
     internal struct patch_PickupIndex
     {

--- a/ItemLib.MonoMod/ItemLib_MonoMod.cs
+++ b/ItemLib.MonoMod/ItemLib_MonoMod.cs
@@ -38,6 +38,12 @@ namespace RoR2
         public static extern BuffDef GetBuffDef(BuffIndex buffIndex);
     }
 
+    //internal class patch_CombatDirector
+    //{
+    //    [NoReadOnly]
+    //    private static CombatDirector.EliteTierDef[] eliteTiers;
+    //}
+
     [Serializable]
     internal struct patch_PickupIndex
     {

--- a/ItemLib/CilExtensions.cs
+++ b/ItemLib/CilExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+
+namespace ItemLib
+{
+    public static class CilExtensions
+    {
+        public static int DecodeLdcI4Arg(this Instruction x)
+        {
+            if (x.OpCode == OpCodes.Ldc_I4_0)
+                return 0;
+            if (x.OpCode == OpCodes.Ldc_I4_1)
+                return 1;
+            if (x.OpCode == OpCodes.Ldc_I4_2)
+                return 2;
+            if (x.OpCode == OpCodes.Ldc_I4_3)
+                return 3;
+            if (x.OpCode == OpCodes.Ldc_I4_4)
+                return 4;
+            if (x.OpCode == OpCodes.Ldc_I4_5)
+                return 5;
+            if (x.OpCode == OpCodes.Ldc_I4_6)
+                return 6;
+            if (x.OpCode == OpCodes.Ldc_I4_7)
+                return 7;
+            if (x.OpCode == OpCodes.Ldc_I4_8)
+                return 8;
+            if (x.OpCode == OpCodes.Ldc_I4_M1)
+                return -1;
+            if (x.OpCode == OpCodes.Ldc_I4_S)
+                return (byte) x.Operand;
+            if (x.OpCode == OpCodes.Ldc_I4)
+                return (int) x.Operand;
+
+            throw new ArgumentException("Instruction is not an Ldc_I4 variant");
+        }
+    }
+}

--- a/ItemLib/CustomBuff.cs
+++ b/ItemLib/CustomBuff.cs
@@ -6,10 +6,26 @@ using UnityEngine;
 
 namespace ItemLib
 {
+    /// <summary>
+    /// Class that defines a custom buff type for use in the game;
+    /// you may omit the index in the BuffDef, as that will
+    /// be assigned by ItemLib.
+    /// </summary>
     public sealed class CustomBuff
     {
+        /// <summary>
+        /// Name of the Buff for the purposes of looking up its index
+        /// </summary>
         public string Name;
+
+        /// <summary>
+        /// Definition of the Buff
+        /// </summary>
         public BuffDef BuffDef;
+
+        /// <summary>
+        /// Icon that will be displayed when this Buff is active
+        /// </summary>
         public Sprite Icon;
 
         public CustomBuff(string name, BuffDef buffDef, Sprite icon)

--- a/ItemLib/CustomBuff.cs
+++ b/ItemLib/CustomBuff.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using RoR2;
+using UnityEngine;
+
+namespace ItemLib
+{
+    public sealed class CustomBuff
+    {
+        public string Name;
+        public BuffDef BuffDef;
+        public Sprite Icon;
+
+        public CustomBuff(string name, BuffDef buffDef, Sprite icon)
+        {
+            Name = name;
+            BuffDef = buffDef;
+            Icon = icon;
+        }
+    }
+}

--- a/ItemLib/CustomElite.cs
+++ b/ItemLib/CustomElite.cs
@@ -5,15 +5,48 @@ using RoR2;
 
 namespace ItemLib
 {
+    /// <summary>
+    /// Class that defines a custom Elite type for use in the game.
+    /// All Elites consistent of an Elite definition, a <see cref="CustomEquipment"/>
+    /// and a <see cref="CustomBuff"/>.  The equipment is automatically provided to
+    /// the Elite when it spawns and is configured to passively apply the buff.
+    /// Note that if Elite Spawning Overhaul is enabled, you'll also want to create a <see cref="EliteAffixCard"/>
+    /// to allow the combat director to spawn your elite type.
+    /// </summary>
     public sealed class CustomElite
     {
+        /// <summary>
+        /// Name of the Elite, for purposes of looking up its index
+        /// </summary>
         public string Name;
+
+        /// <summary>
+        /// Elite definition (you can omit the index references, as those will be filled in automatically by ItemLib)
+        /// </summary>
         public EliteDef EliteDef;
+
+        /// <summary>
+        /// Custom equipment that the Elite will carry; do note that this is something that may (rarely) drop from the Elite when killed,
+        /// so players can also end up with this equipment
+        /// </summary>
         public CustomEquipment Equipment;
+
+        /// <summary>
+        /// Custom buff that is applied passively by the equipment; note that this can be active on the player
+        /// if they're using Wake of Vultures or pick up the equipment, so you'll need to decide what impact
+        /// the elite buff should have on players.
+        /// </summary>
         public CustomBuff Buff;
+
+        /// <summary>
+        /// Tier for the elite, where 1 is standard elites (Fire, Ice, Lightning) and 2 is currently just Poison (Malachite).
+        /// If Elite Spawning Overhaul is disabled, it will use this tier to set cost/hp/dmg scaling.  Even if your mod is
+        /// only intended to work with ESO enabled, this should still be set to a valid number 1-2 for compatibility with
+        /// the underlying game code.
+        /// </summary>
         public int Tier;
 
-        public CustomElite(string name, EliteDef eliteDef, CustomEquipment equipment, CustomBuff buff, int tier)
+        public CustomElite(string name, EliteDef eliteDef, CustomEquipment equipment, CustomBuff buff, int tier = 1)
         {
             Name = name;
             EliteDef = eliteDef;

--- a/ItemLib/CustomElite.cs
+++ b/ItemLib/CustomElite.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using RoR2;
+
+namespace ItemLib
+{
+    public sealed class CustomElite
+    {
+        public string Name;
+        public EliteDef EliteDef;
+        public CustomEquipment Equipment;
+        public CustomBuff Buff;
+        public int Tier;
+
+        public CustomElite(string name, EliteDef eliteDef, CustomEquipment equipment, CustomBuff buff, int tier)
+        {
+            Name = name;
+            EliteDef = eliteDef;
+            Equipment = equipment;
+            Buff = buff;
+            Tier = tier;
+        }
+    }
+}

--- a/ItemLib/EliteAffixCard.cs
+++ b/ItemLib/EliteAffixCard.cs
@@ -5,6 +5,14 @@ using RoR2;
 
 namespace ItemLib
 {
+    /// <summary>
+    /// Card specifying the spawn probability, cost and power level of a particular elite type.  Costlier elites
+    /// will tend to only show up later in the game, but may still spawn quite often once the difficulty gets high
+    /// enough that the CombatDirector has a lot of budget to work with.  You can use <see cref="spawnWeight"/> to
+    /// adjust how frequently the elite type spawns when it can afford it and can individually tweak each elite
+    /// type's cost/dmg/hp boosts.  For extra fun, consider hooking the onSpawned delegate to add extra power, such
+    /// as by granting items.  You can also create multiple cards for the same elite type, with different costs/weights.
+    /// </summary>
     public sealed class EliteAffixCard
     {
         public EliteIndex eliteType;

--- a/ItemLib/EliteAffixCard.cs
+++ b/ItemLib/EliteAffixCard.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using RoR2;
+
+namespace ItemLib
+{
+    public sealed class EliteAffixCard
+    {
+        public EliteIndex eliteType;
+
+        /// <summary>
+        /// Base spawn weight for this elite type; a value of 1.0f makes it equally likely as 'vanilla' elites
+        /// </summary>
+        public float spawnWeight = 1.0f;
+
+        /// <summary>
+        /// Cost multiplier that this elite type applies to the base spawn card; a value of 6.0f is typical for tier 1 elites
+        /// </summary>
+        public float costMultiplier = 1.0f;
+
+        /// <summary>
+        /// Damage boost effect for this elite type; a value of 2.0f is typical for tier 1 elites
+        /// </summary>
+        public float damageBoostCoeff = 1.0f;
+
+        /// <summary>
+        /// Health boost effect for this elite type; a value of 4.7f is typical for tier 1 elites
+        /// </summary>
+        public float healthBoostCoeff = 1.0f;
+
+        /// <summary>
+        /// Delegate that evaluates whether this elite type can be spawned currently; for example, checking Run.instance.loopClearCount
+        /// </summary>
+        public Func<bool> isAvailable = () => true;
+
+        /// <summary>
+        /// Map of multipliers to spawn weight by spawn card name
+        /// </summary>
+        public Dictionary<string, float> spawnCardMultipliers = new Dictionary<string, float>();
+
+        /// <summary>
+        /// Delegate that will be called after this elite affix is spawned; you can use this to do any extra setup, like granting it items
+        /// </summary>
+        public Action<CharacterMaster> onSpawned = null;
+
+        /// <summary>
+        /// Get the adjusted spawn weight for this card, taking into account
+        /// both the base weight for this elite and any card-specific multiplier.
+        /// </summary>
+        /// <param name="monsterCard">Card to be spawned</param>
+        /// <returns>Adjusted spawn weight</returns>
+        public float GetSpawnWeight(DirectorCard monsterCard)
+        {
+            if (!spawnCardMultipliers.TryGetValue(monsterCard.spawnCard.name, out var multiplier))
+                multiplier = 1;
+
+            return multiplier*spawnWeight;
+        }
+    }
+}

--- a/ItemLib/EliteSpawningOverhaul.cs
+++ b/ItemLib/EliteSpawningOverhaul.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using RoR2;
+namespace ItemLib
+{
+    public static class EliteSpawningOverhaul
+    {
+        public static void Init()
+        {
+            On.RoR2.CombatDirector.PrepareNewMonsterWave += CombatDirectorOnPrepareNewMonsterWave;
+            IL.RoR2.CombatDirector.AttemptSpawnOnTarget += CombatDirectorOnAttemptSpawnOnTarget;
+
+            //We also need to override usages of highestEliteCostMultiplier, but there's no built-in hook for this
+            //We have to use MonoMod directly
+            var method = typeof(CombatDirector).GetMethod("get_highestEliteCostMultiplier");
+            MonoMod.RuntimeDetour.HookGen.HookEndpointManager.Modify(method, (Action<ILContext>)CombatDirectorGetHighestEliteCostMultiplier);
+
+            //Create default cards for vanilla elites
+            Cards.Add(new EliteAffixCard
+            {
+                spawnWeight = 1.0f,
+                costMultiplier = 6.0f,
+                damageBoostCoeff = 2.0f,
+                healthBoostCoeff = 4.7f,
+                eliteType = EliteIndex.Fire
+            });
+            Cards.Add(new EliteAffixCard
+            {
+                spawnWeight = 1.0f,
+                costMultiplier = 6.0f,
+                damageBoostCoeff = 2.0f,
+                healthBoostCoeff = 4.7f,
+                eliteType = EliteIndex.Ice
+            });
+            Cards.Add(new EliteAffixCard
+            {
+                spawnWeight = 1.0f,
+                costMultiplier = 6.0f,
+                damageBoostCoeff = 2.0f,
+                healthBoostCoeff = 4.7f,
+                eliteType = EliteIndex.Lightning
+            });
+            Cards.Add(new EliteAffixCard
+            {
+                spawnWeight = 1.0f,
+                costMultiplier = 36.0f,
+                damageBoostCoeff = 6.0f,
+                healthBoostCoeff = 28.2f,
+                eliteType = EliteIndex.Poison,
+                isAvailable = () => Run.instance.loopClearCount > 0
+            });
+
+            Enabled = true;
+        }
+
+        public static bool Enabled { get; private set; }
+
+        public static List<EliteAffixCard> Cards { get; } = new List<EliteAffixCard>();
+
+        private static Dictionary<CombatDirector, EliteAffixCard> _chosenAffix = new Dictionary<CombatDirector, EliteAffixCard>();
+
+        private static void CombatDirectorOnPrepareNewMonsterWave(On.RoR2.CombatDirector.orig_PrepareNewMonsterWave orig, CombatDirector self, DirectorCard monsterCard)
+        {
+            //NOTE: We're completely rewriting this method, so we don't call back to the orig
+
+            self.SetFieldValue("currentMonsterCard", monsterCard);
+            _chosenAffix[self] = null;
+            if (!((CharacterSpawnCard) monsterCard.spawnCard).noElites)
+            {
+                var eliteSelection = new WeightedSelection<EliteAffixCard>();
+
+                foreach (var card in Cards)
+                {
+                    var weight = card.GetSpawnWeight(monsterCard);
+                    if (weight > 0 && card.isAvailable())
+                    {
+                        var cost = monsterCard.cost*card.costMultiplier;
+                        if (cost <= self.monsterCredit)
+                        {
+                            eliteSelection.AddChoice(card, weight);
+                        }
+                    }
+                }
+
+                if (eliteSelection.Count > 0)
+                {
+                    var rng = self.GetFieldValue<Xoroshiro128Plus>("rng");
+                    var card = eliteSelection.Evaluate(rng.nextNormalizedFloat);
+                    _chosenAffix[self] = card;
+                }
+            }
+
+            self.lastAttemptedMonsterCard = monsterCard;
+            self.SetFieldValue("spawnCountInCurrentWave", 0);
+        }
+
+        private delegate EliteIndex GetNextEliteDel(CombatDirector self, ref float cost, out float scaledCost);
+
+        private delegate void GetCoeffsDel(CombatDirector self, out float hpCoeff, out float dmgCoeff);
+
+        private static void CombatDirectorOnAttemptSpawnOnTarget(ILContext il)
+        {
+            var c = new ILCursor(il);
+
+            //First, we rewrite the section of the code that haandles scaling cost by elite tier, to see if it can spawn as elite
+            //Since cost scaling is now part of the card, we use that instead of the tier def
+            c.GotoNext(i => i.MatchLdarg(0),
+                       i => i.MatchLdfld("RoR2.CombatDirector", "currentActiveEliteTier"));
+
+            //Getting the next elite also needs to set some local variables as side effects for the rest of the code
+            //Thus, the ugly-looking delegate
+            c.Emit(OpCodes.Ldarg_0);
+            c.Emit(OpCodes.Ldloca_S, (byte) 0);
+            c.Emit(OpCodes.Ldloca_S, (byte) 1);
+            c.EmitDelegate<GetNextEliteDel>(GetNextElite);
+            c.Emit(OpCodes.Stloc_3);
+            
+            //And we'll need to skip over the code in the original method
+            var skip1 = c.DefineLabel();
+            c.Emit(OpCodes.Br, skip1);
+            c.GotoNext(i => i.MatchLdarg(0),
+                       i => i.MatchLdfld("RoR2.CombatDirector", "currentMonsterCard"));
+            c.MarkLabel(skip1);
+
+            //The original code now spawns the actual monster and assigns it to a squad, if applicable
+            //We're going to modify once it reaches the part where it starts applying the Elite-related changes
+            c.GotoNext(i => i.MatchLdloc(2),
+                       i => i.MatchLdfld("RoR2.CombatDirector/EliteTierDef", "healthBoostCoefficient"));
+
+            //We're going to replace these 6 instructions:
+            //IL_03d5: ldloc.2
+            //IL_03d6: ldfld float32 RoR2.CombatDirector / EliteTierDef::healthBoostCoefficient
+            //IL_03db: stloc.s V_8
+            //IL_03dd: ldloc.2
+            //IL_03de: ldfld float32 RoR2.CombatDirector / EliteTierDef::damageBoostCoefficient
+            //IL_03e3: stloc.s V_9
+            c.RemoveRange(6);
+            c.Emit(OpCodes.Ldarg_0);
+            c.Emit(OpCodes.Ldloca_S, (byte) 8);
+            c.Emit(OpCodes.Ldloca_S, (byte) 9);
+            c.EmitDelegate<GetCoeffsDel>(GetCoeffs);
+
+            //Finally, just before it launches the spawnEffect, we'll give the card's creator a chance to apply changes to the character
+            c.GotoNext(i => i.MatchLdarg(0),
+                       i => i.MatchLdfld("RoR2.CombatDirector", "spawnEffectPrefab"));
+            c.Emit(OpCodes.Ldarg_0);
+            c.Emit(OpCodes.Ldloc_S, (byte) 10);
+            c.EmitDelegate<Action<CombatDirector, CharacterMaster>>(RunOnSpawn);
+        }
+
+        private static EliteIndex GetNextElite(CombatDirector self, ref float cost, out float scaledCost)
+        {
+            _chosenAffix.TryGetValue(self, out var affix);
+            scaledCost = affix != null ? affix.costMultiplier*cost : cost;
+            if (scaledCost < self.monsterCredit)
+            {
+                cost = scaledCost;
+                return affix?.eliteType ?? EliteIndex.None;
+            }
+
+            return EliteIndex.None;
+        }
+
+        private static void GetCoeffs(CombatDirector self, out float hpCoeff, out float dmgCoeff)
+        {
+            _chosenAffix.TryGetValue(self, out var affix);
+            if (affix != null)
+            {
+                hpCoeff = affix.healthBoostCoeff;
+                dmgCoeff = affix.damageBoostCoeff;
+            }
+            else
+            {
+                hpCoeff = 1;
+                dmgCoeff = 1;
+            }
+        }
+
+        private static void RunOnSpawn(CombatDirector self, CharacterMaster master)
+        {
+            _chosenAffix.TryGetValue(self, out var affix);
+            affix?.onSpawned?.Invoke(master);
+        }
+
+        private static void CombatDirectorGetHighestEliteCostMultiplier(ILContext il)
+        {
+            var c = new ILCursor(il);
+
+            //We completely replace this getter
+            c.RemoveRange(c.Instrs.Count);
+            c.EmitDelegate<Func<float>>(GetHighestEliteCostMultiplier);
+            c.Emit(OpCodes.Ret);
+        }
+
+        private static float GetHighestEliteCostMultiplier()
+        {
+            return Cards.Count == 0 ? 1.0f : Cards.Max(c => c.costMultiplier);
+        }
+    }
+}

--- a/ItemLib/EliteSpawningOverhaul.cs
+++ b/ItemLib/EliteSpawningOverhaul.cs
@@ -9,9 +9,14 @@ using MonoMod.Cil;
 using RoR2;
 namespace ItemLib
 {
+    /// <summary>
+    /// Provides a toolset for customizing elite spawning on a per-elite basis; this may be disabled in the ItemLib configuration,
+    /// so consumers of this class may look at the <see cref="Enabled"/> property to check this.  Cards are automatically created
+    /// for the vanilla elite types with parameters matching those from the vanilla game.
+    /// </summary>
     public static class EliteSpawningOverhaul
     {
-        public static void Init()
+        internal static void Init()
         {
             On.RoR2.CombatDirector.PrepareNewMonsterWave += CombatDirectorOnPrepareNewMonsterWave;
             IL.RoR2.CombatDirector.AttemptSpawnOnTarget += CombatDirectorOnAttemptSpawnOnTarget;
@@ -59,8 +64,15 @@ namespace ItemLib
             Enabled = true;
         }
 
+        /// <summary>
+        /// Whether ESO is enabled; if false, any Cards will be ignored
+        /// </summary>
         public static bool Enabled { get; private set; }
 
+        /// <summary>
+        /// The cards used for assigning Elite affixes to spawned enemies; note that you may register multiple cards with the same EliteIndex,
+        /// which can be useful for creating different 'tiers' of the same elite type, with stat boosts or other customization using the onSpawned delegate.
+        /// </summary>
         public static List<EliteAffixCard> Cards { get; } = new List<EliteAffixCard>();
 
         private static Dictionary<CombatDirector, EliteAffixCard> _chosenAffix = new Dictionary<CombatDirector, EliteAffixCard>();

--- a/ItemLib/ItemAttribute.cs
+++ b/ItemLib/ItemAttribute.cs
@@ -9,7 +9,9 @@ namespace ItemLib
         public enum ItemType
         {
             Item,
-            Equipment
+            Equipment,
+            Buff,
+            Elite
         }
 
         public readonly ItemType Type;

--- a/ItemLib/ItemLib.cs
+++ b/ItemLib/ItemLib.cs
@@ -148,7 +148,9 @@ namespace ItemLib
                     maxTier = EliteMaxTier;
 
                 //Get CombatDirector's existing elite tier table
-                var tiers = (CombatDirector.EliteTierDef[])typeof(CombatDirector).GetField("eliteTiers", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
+                var tiersField =
+                    typeof(CombatDirector).GetField("eliteTiers", BindingFlags.Static | BindingFlags.NonPublic);
+                var tiers = (CombatDirector.EliteTierDef[])tiersField.GetValue(null);
 
                 //We're going to replace it with an entirely new table
                 var newTiers = new CombatDirector.EliteTierDef[maxTier + 1];
@@ -156,7 +158,10 @@ namespace ItemLib
                 {
                     var newElites = CustomEliteList.Where(e => e.Tier == i).Select(e => e.EliteDef.eliteIndex).ToArray();
                     if (newElites.Length == 0)
+                    {
+                        newTiers[i] = tiers[i];
                         continue;
+                    }
 
                     if (i < tiers.Length)
                     {
@@ -180,6 +185,8 @@ namespace ItemLib
                         newTiers[i] = tier;
                     }
                 }
+
+                tiersField.SetValue(null, newTiers);
             }
         }
 
@@ -718,7 +725,7 @@ namespace ItemLib
             var lunarItems = CustomItemList.Where(x => x.ItemDef.tier == ItemTier.Lunar).Select(x => (x.ItemDef.itemIndex)).ToArray();
             var bossItems = CustomItemList.Where(x => x.ItemDef.tier == ItemTier.Boss).Select(x => (x.ItemDef.itemIndex)).ToArray();
 
-            var equipments = CustomEquipmentList.Select(x => (x.EquipmentDef.equipmentIndex)).ToArray();
+            var equipments = CustomEquipmentList.Where(c => c.EquipmentDef.canDrop).Select(x => (x.EquipmentDef.equipmentIndex)).ToArray();
             ItemDropAPI.AddToDefaultByTier(ItemTier.Tier1, t1Items);
             ItemDropAPI.AddToDefaultByTier(ItemTier.Tier2, t2Items);
             ItemDropAPI.AddToDefaultByTier(ItemTier.Tier3, t3Items);

--- a/ItemLib/ItemLib.csproj
+++ b/ItemLib/ItemLib.csproj
@@ -9,6 +9,10 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>ItemLib.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\libs\Assembly-CSharp.dll</HintPath>

--- a/ItemLib/ItemLib.csproj
+++ b/ItemLib/ItemLib.csproj
@@ -22,6 +22,9 @@
     <Reference Include="Mono.Cecil">
       <HintPath>..\libs\Mono.Cecil.dll</HintPath>
     </Reference>
+    <Reference Include="MonoMod.RuntimeDetour">
+      <HintPath>..\..\JarlykMods\Dependencies\MonoMod.RuntimeDetour.dll</HintPath>
+    </Reference>
     <Reference Include="MonoMod.Utils">
       <HintPath>..\libs\MonoMod.Utils.dll</HintPath>
     </Reference>

--- a/ItemLib/ItemLibConfig.cs
+++ b/ItemLib/ItemLibConfig.cs
@@ -1,0 +1,19 @@
+﻿using BepInEx.Configuration;
+using UnityEngine;
+
+namespace ItemLib
+{
+    public static class ItemLibConfig
+    {
+        internal static void Init(ConfigFile config)
+        {
+            EnableEliteSpawningOverhaul = config.Wrap(
+                "Features",
+                "EnableEliteSpawningOverhaul",
+                "Whether to enable overhauled version of elite spawning; some mods may depend on this being enabled",
+                true);
+        }
+
+        public static ConfigWrapper<bool> EnableEliteSpawningOverhaul;
+    }
+}

--- a/ItemLib/ItemLibPlugin.cs
+++ b/ItemLib/ItemLibPlugin.cs
@@ -31,6 +31,12 @@ namespace ItemLib
 
             On.RoR2.RoR2Application.UnitySystemConsoleRedirector.Redirect += orig => { };
 
+            if (ItemLibConfig.EnableEliteSpawningOverhaul.Value)
+            {
+                EliteSpawningOverhaul.Init();
+                Debug.Log("Elite Spawning Overhaul has been enabled");
+            }
+
             On.RoR2.Console.Awake += (orig, self) =>
             {
                 CommandHelper.RegisterCommands(self);

--- a/ItemLib/ItemLibPlugin.cs
+++ b/ItemLib/ItemLibPlugin.cs
@@ -27,6 +27,7 @@ namespace ItemLib
 #if DEBUG
             Logger.LogInfo("[ItemLib] Debug");
 #endif
+            ItemLibConfig.Init(Config);
             ItemLib.Initialize();
 
             On.RoR2.RoR2Application.UnitySystemConsoleRedirector.Redirect += orig => { };

--- a/ItemLib/ItemLibPlugin.cs
+++ b/ItemLib/ItemLibPlugin.cs
@@ -13,7 +13,7 @@ namespace ItemLib
     [BepInPlugin(ModGuid, ModName, ModVer)]
     public class ItemLibPlugin : BaseUnityPlugin
     {
-        public const string ModVer = "0.0.15";
+        public const string ModVer = "0.1.0";
         public const string ModName = "ItemLib";
         public const string ModGuid = "dev.iDeathHD.ItemLib";
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ItemLib
-A library for custom items and equipments in Risk of Rain 2.
+A library for custom items, equipments, buffs and elites in Risk of Rain 2.
 
 ### Table of Contents
 
@@ -27,8 +27,8 @@ You may have to fix the assembly reference `ItemLib.dll` for the ExampleItemMod 
 
 ### Using the library for your mod
 
-Once your project is ready you'll want to have a method defined that will return a CustomItem / CustomEquipment object and have an Item Attribute at the top so that the library can load it. \
-Depending on what you want (item or equipment) you'll want to change the ItemType (enum) in the attribute. \
+Once your project is ready you'll want to have a method defined that will return a CustomItem / CustomEquipment / CustomBuff/ CustomElite object and have an Item Attribute at the top so that the library can load it. \
+Depending on what you want, you'll want to change the ItemType (enum) in the attribute. \
 Leave both `pickupModelPath` and/or `pickupIconPath` empty if you want to have a custom prefab / icon for your item. \
 For having a custom prefab and icon you will need to make an AssetBundle in Unity, you could also download the unitypackage and use it as an example.
 
@@ -140,3 +140,12 @@ On.RoR2.EquipmentSlot.PerformEquipmentAction += (orig, self, equipmentIndex) =>
 	return orig(self, equipmentIndex); // must
 };
 ```
+
+### Custom Buffs
+Buffs in RoR2 are status effects, which may or may not be 'buffs' in the beneficial sense.  By creating a custom buff, it will add an array entry to all characters that can track whether that buff is present, will automatically display an icon when the buff is active and also gives you access to handy methods like adding a timed buff to a character that automatically decays.  To create a custom buff, just provide an Icon, buffColor and whether it's stackable.  IF no Icon is specified, it will default to a square of the buffColor provided.
+
+### Custom Elites
+
+
+### Elite Spawning Overhaul
+The built-in tier system for elites is fairly limiting.  For example, if you want an elite type to be costly, like Malachites, it will also end up having the huge dmg and hp boosts for Malachites, which you might not want in all cases.  ESO provides an alternate mechanism for elite spawning with more flexibility, modeled after the 'Spawn Card' system.  This feature may be disabled in the configuration for ItemLib, in which case spawning will revert to the vanilla tier-based mechanism.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You may have to fix the assembly reference `ItemLib.dll` for the ExampleItemMod 
 
 ### Using the library for your mod
 
-Once your project is ready you'll want to have a method defined that will return a CustomItem / CustomEquipment / CustomBuff/ CustomElite object and have an Item Attribute at the top so that the library can load it. \
+Once your project is ready you'll want to have a method defined that will return a CustomItem / CustomEquipment / CustomBuff / CustomElite object and have an Item Attribute at the top so that the library can load it. \
 Depending on what you want, you'll want to change the ItemType (enum) in the attribute. \
 Leave both `pickupModelPath` and/or `pickupIconPath` empty if you want to have a custom prefab / icon for your item. \
 For having a custom prefab and icon you will need to make an AssetBundle in Unity, you could also download the unitypackage and use it as an example.
@@ -141,11 +141,87 @@ On.RoR2.EquipmentSlot.PerformEquipmentAction += (orig, self, equipmentIndex) =>
 };
 ```
 
-### Custom Buffs
-Buffs in RoR2 are status effects, which may or may not be 'buffs' in the beneficial sense.  By creating a custom buff, it will add an array entry to all characters that can track whether that buff is present, will automatically display an icon when the buff is active and also gives you access to handy methods like adding a timed buff to a character that automatically decays.  To create a custom buff, just provide an Icon, buffColor and whether it's stackable.  IF no Icon is specified, it will default to a square of the buffColor provided.
+#### Custom Buffs
+Buffs in RoR2 are status effects, which may or may not be 'buffs' in the beneficial sense.  By creating a custom buff, it will add an array entry to all characters that can track whether that buff is present, will automatically display an icon when the buff is active and also gives you access to handy methods like adding a timed buff to a character that automatically decays.  To create a custom buff, just provide an Icon, buffColor and whether it's stackable.  If no Icon is specified, it will default to a square of the buffColor provided.  To make the buff have effects in the code, hook whatever methods you want to modify, then use CharacterBody.HasBuff to check for its presence.  You can use AddBuff and AddTimedBuff to apply the buff.
+```csharp
+	[Item(ItemAttribute.ItemType.Buff)]
+	public static CustomBuff TestBuff()
+	{
+		LoadAssets();
 
-### Custom Elites
+		var buffDef = new BuffDef
+		{
+			buffColor = Color.green,
+			canStack = false
+		};
 
+		Sprite icon = null; //Can load a custom sprite asset here; null defaults to a blank colored square
+		return new CustomBuff("MyBuff", buffDef, icon);
+	}
+```
 
-### Elite Spawning Overhaul
-The built-in tier system for elites is fairly limiting.  For example, if you want an elite type to be costly, like Malachites, it will also end up having the huge dmg and hp boosts for Malachites, which you might not want in all cases.  ESO provides an alternate mechanism for elite spawning with more flexibility, modeled after the 'Spawn Card' system.  This feature may be disabled in the configuration for ItemLib, in which case spawning will revert to the vanilla tier-based mechanism.
+#### Custom Elites
+Elites in Risk of Rain 2 are internally made up of three key elements.  There is an EliteDef, plus every elite has a custom Equipment, which then passive applies a custom Buff.  To create custom elites, you only need to implement one method and the associated equipment/buff will automatically be created and linked to it.  This method is implemented very much like the custom items and equipment:
+```csharp
+        [Item(ItemAttribute.ItemType.Elite)]
+        public static CustomElite TestElite()
+        {
+            LoadAssets();
+
+            var eliteDef = new EliteDef
+            {
+                modifierToken = "Cloaky",
+                color = new Color32(255, 105, 180, 255)
+            };
+            var equipDef = new EquipmentDef
+            {
+                cooldown = 10f,
+                pickupModelPath = "",
+                pickupIconPath = "",
+                nameToken = "Cloaky",
+                pickupToken = "Cloaky",
+                descriptionToken = "Cloaky",
+                canDrop = false,
+                enigmaCompatible = false
+            };
+            var buffDef = new BuffDef
+            {
+                buffColor = eliteDef.color,
+                canStack = false
+            };
+
+            var equip = new CustomEquipment(equipDef, _prefab, _icon, _itemDisplayRules);
+            var buff = new CustomBuff("Affix_Cloaky", buffDef, null);              
+            var elite = new CustomElite("Cloaky", eliteDef, equip, buff, 1);
+            return elite;
+        }
+```
+Note that we're reusing equipment _prefab and _icon assets from the Equipment example here.  The final parameter of the CustomElite constructor here is the 'tier'.  According to vanila spawning mechanics, tiers 1 and 2 have different modifiers, as well as some additional requirements (tier 2 can only spawn after the first loop.)  You can specify a tier (1 or 2) of you wish to use the vanilla spawning or you can use the overhauled Elite spawning mechanics described below.
+
+#### Elite Spawning Overhaul
+The built-in tier system for elites is fairly limiting.  For example, if you want an elite type to be costly, like Malachites, it will also end up having the huge dmg and hp boosts for Malachites, which you might not want in all cases.  ESO provides an alternate mechanism for elite spawning with more flexibility, modeled after the 'SpawnCard' system RoR2 uses.  This feature may be disabled in the configuration for ItemLib, in which case spawning will revert to the vanilla tier-based mechanism.
+
+Once you've defined a custom elite, you can make it eligible for spawning like this:
+```csharp
+	//Overall, this elite is pretty rare
+	//(Though, by the way, it has a built-in sticky bomb)
+	var card = new EliteAffixCard
+	{
+		spawnWeight = 0.1f,				//Only 10% as likely to spawn compared to baseline vanilla elites
+		costMultiplier = 6.0f,			//Costs 6x, which is the same as tier 1 elites
+		damageBoostCoeff = 2.0f,		//Damage boost the same as vanilla elites
+		healthBoostCoeff = 4.7f,		//Health boost the same as vanilla elites
+		eliteType = (EliteIndex) eliteId,
+		onSpawned = m => m.inventory.GiveItem(ItemIndex.StickyBomb, 1)
+	};
+
+	//Except it's really common on beetles for some reason
+	card.spawnCardMultipliers.Add("cscbeetle", 20);	//20x more likely than vanilla for this elite type to be chosen on Beetles
+
+	//Add it to the list so that it's available for spawning with ESO
+	EliteSpawningOverhaul.Cards.Add(card);
+```
+
+Note that there is an onSpawned hook provided that you can use to set up each newly created elite CharacterMaster instance; in this case, the elite monster is granted an item.  To add other types of effects caused by this elite, hook areas of the code you want to change and then use CharacterBody.HasBuff to check for the elite buff.  Do remember that players can get this buff too if they have Wake of Vultures and kill an elite with your new type or if they pickup the rarely dropped elite equipment.
+
+It's possible to create more than one EliteAffixCard for the same elite type, giving the cards different weights, costs, boosts, etc.  This can let you create multiple tiers of your elite types or to add new versions of the vanilla elites with different power levels.  The vanilla elite settings can also be modified by modifying the elements in EliteSpawningOverhaul.Cards, though bear in mind that other mods might try to do the same thing.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Buffs in RoR2 are status effects, which may or may not be 'buffs' in the benefic
 ```
 
 #### Custom Elites
-Elites in Risk of Rain 2 are internally made up of three key elements.  There is an EliteDef, plus every elite has a custom Equipment, which then passive applies a custom Buff.  To create custom elites, you only need to implement one method and the associated equipment/buff will automatically be created and linked to it.  This method is implemented very much like the custom items and equipment:
+Elites in Risk of Rain 2 are internally made up of three key elements.  There is an EliteDef, plus every elite has a custom Equipment, which then passively applies a custom Buff.  To create custom elites, you only need to implement one method and the associated equipment/buff will automatically be created and linked to it.  This method is implemented very much like the custom items and equipment:
 ```csharp
         [Item(ItemAttribute.ItemType.Elite)]
         public static CustomElite TestElite()
@@ -207,7 +207,7 @@ Once you've defined a custom elite, you can make it eligible for spawning like t
 	//(Though, by the way, it has a built-in sticky bomb)
 	var card = new EliteAffixCard
 	{
-		spawnWeight = 0.1f,				//Only 10% as likely to spawn compared to baseline vanilla elites
+		spawnWeight = 0.1f,			//Only 10% as likely to spawn compared to baseline vanilla elites
 		costMultiplier = 6.0f,			//Costs 6x, which is the same as tier 1 elites
 		damageBoostCoeff = 2.0f,		//Damage boost the same as vanilla elites
 		healthBoostCoeff = 4.7f,		//Health boost the same as vanilla elites

--- a/Utilities/Reflection.cs
+++ b/Utilities/Reflection.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 
-public static class Reflection
+internal static class Reflection
 {
     private static readonly BindingFlags _defaultFlags
         = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;


### PR DESCRIPTION
I think this is fairly stable now and would like to have these changes merged into the main release on Thunderstore so that it can be used as a dependency.  The most substantial game-impacting changes are in the Elite Spawning Overhaul, so I've added a configuration option to disable this.  Let me know if you have any questions or concerns.